### PR TITLE
fix typo in how to start postgres in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ docker run --name db \
   -e POSTGRES_DB=gorm \
   -e POSTGRES_PASSWORD="<mypassword>" \
   --net terranet \
-  --restart=always postgres -d
+  -d \
+  --restart=always postgres
 docker run -p 8080:8080 \
   -e AWS_REGION="<region>" \
   -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \


### PR DESCRIPTION
The title says it all. The `-d` needs to be passed before the container image.